### PR TITLE
Add network graph for book relations

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -220,7 +220,18 @@ tr.shown td.details-control {
 
 }
 
-.modal-backdrop
-{
+.modal-backdrop{
     opacity:0.5 !important;
+}
+
+#graph {
+  overflow-y: visible;
+}
+
+.vis-network {
+  overflow-y: visible;
+}
+
+img {
+  margin: 2px;
 }

--- a/index.html
+++ b/index.html
@@ -2,28 +2,33 @@
 
 <head>
     <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.10.16/datatables.min.css" /> -->
-    <link rel="stylesheet" type="text/css" href="css/styles.css" />
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
         crossorigin="anonymous"></script>
     <!-- <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.16/datatables.min.js"></script> -->
 
 
 
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Amiri&display=swap" >
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.0.0/dt-1.10.16/datatables.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.1/css/buttons.dataTables.min.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.10.16/b-1.5.1/b-html5-1.5.1/cr-1.4.1/datatables.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/browse/vis-network@9.0.4/dist/dist/vis-network.css" />
+    <link rel="stylesheet" type="text/css" href="css/styles.css" />
+
     <!-- old version -->
     <!-- <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.0.0/dt-1.10.16/datatables.min.js"></script> -->
     <!-- <script type="text/javascript" src="https://cdn.datatables.net/v/dt/jq-3.3.1/dt-1.10.18/b-1.5.6/b-html5-1.5.6/fh-3.1.4/r-2.2.2/rr-1.2.4/datatables.min.js"></script> -->
 
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.10.16/b-1.5.1/b-html5-1.5.1/cr-1.4.1/datatables.min.css"/>
+
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/pdfmake.min.js"></script>
     <!-- <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/vfs_fonts.js"></script> -->
     <script type="text/javascript" src="js/vfs_fonts.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.10.16/b-1.5.1/b-html5-1.5.1/cr-1.4.1/datatables.min.js"></script>
     <script type="text/javascript" src="js/arabic.js"></script>
     <script src="https://kit.fontawesome.com/03581ef0eb.js"></script>
-    <link href="https://fonts.googleapis.com/css?family=Amiri&display=swap" rel="stylesheet">
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGJD7641K2"></script>
 <script>
@@ -49,16 +54,15 @@ body{
 </div>
 
 <div class="modal" tabindex="-1" role="dialog" id="bookRelModal" role="dialog">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
+  <div class="modal-dialog" role="document" style="width:80%;max-width:1250px;height:90vh;">
+    <div class="modal-content" style="width:80%;max-width:1250px;height:80vh;">
       <div class="modal-header">
         <h5 class="modal-title" id="modal-title"></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body">
-        <p>Modal body text goes here.</p>
+      <div class="modal-body" id="graph">
       </div>
       <div class="modal-footer">
         <!--

--- a/js/test.js
+++ b/js/test.js
@@ -1,0 +1,219 @@
+var bookRelationsUrl = "https://raw.githubusercontent.com/OpenITI/kitab-metadata-automation/master/output/OpenITI_Github_clone_book_relations.json?v1";
+
+var bookRelations = (function(){
+  var relData = null;
+  $.ajax({
+    'async': false,
+    'global': false,
+    //'url': "db/bookRelations.json",
+    'url': bookRelationsUrl,
+    'dataType': "json",
+    'success': function (data) {
+      relData = data;
+    }
+  });
+  return relData;
+})();
+
+var createGraph = function(graph_div, bookuri, bookRelations){
+
+  // define the hierarchical level of each book on the graph based on its date:
+  var nodeLevels = [];
+  for (const relObj of bookRelations[bookuri]){
+    for (const sd of ["source", "dest"]) {
+      try {
+        var date = parseInt(relObj[sd].substr(0,4));
+        console.log(date);
+        if (!nodeLevels.includes(date)) {
+          nodeLevels.push(date);
+        }
+      }
+      catch(e) {
+        var date = parseInt(bookuri.substr(0,4));
+      }
+    }
+  }
+  nodeLevels.sort();
+
+  // initialize nodes and edges datasets:
+  var mainDate = parseInt(bookuri.substr(0,4));
+  level = nodeLevels.indexOf(mainDate);
+  var nodes = new vis.DataSet([{
+    id: bookuri,
+    label: bookuri,
+    level: level,
+    color: "red"  // give the main book node a different color
+  }]);
+  var edges = new vis.DataSet([]);
+
+  // add the data to the nodes and edges datasets:
+  for (const relObj of bookRelations[bookuri]){
+    // add nodes:
+    for (const sd of ["source", "dest"]) {
+      try {
+        var date = parseInt(relObj[sd].substr(0,4));
+        //console.log(date);
+        level = nodeLevels.indexOf(date);
+        //console.log(level);
+      }
+      catch(e) { // no date found in book id: put book on same level as main book
+        var date = parseInt(bookuri.substr(0,4));
+        level = nodeLevels.indexOf(date);
+        //console.log(level);
+      }
+      try {
+        nodes.add({
+          id: relObj[sd],
+          label: relObj[sd],
+          level: level
+        });
+        //nodes.add({id: relObj[sd], label: relObj[sd]});
+      }
+      catch(e) {
+        console.log(relObj[sd] + " already in nodes list");
+      }
+      // add edges:
+      try {
+        edges.add({
+          from: relObj["source"],
+          to: relObj["dest"],
+          label: relObj["main_rel_type"],
+          font: {align: "middle"}
+        })
+      }
+      catch(e) {
+        //console.log(relObj["source"] + " -> " + relObj["dest"] + " already in edges list");
+      }
+    }
+
+
+  }
+
+  // provide the data in the vis format
+  var data = {
+    nodes: nodes,
+    edges: edges
+  };
+  var options = {
+    nodes: {
+      shape: "box"
+    },
+    edges: {
+      smooth: {
+        type: "curvedCW",
+        //type: 'cubicBezier',
+        //forceDirection: 'vertical',
+        //roundness: 1
+      },
+      color: 'lightgray'
+    },
+    layout: {
+      hierarchical: {
+        direction: 'UD',
+        nodeSpacing: 150,
+        //levelSeparation: 150,
+        //shakeTowards: "roots"
+        //sortMethod: "directed"
+      }
+    },
+    interaction: {dragNodes: true},
+    physics: true
+  };
+
+  // initialize your network!
+  var network = new vis.Network(graph_div, data, options);
+}
+
+$(document).ready(function () {
+  var graph_div = document.getElementById('graph');
+  console.log(graph_div);
+  //graph_div.html("<p>TEST</p>");
+  var bookuri = "0275AbuDawudSijistani.Sunan";
+  //var bookuri = "0833IbnJazari.MatnTayyibaNashr";
+  createGraph(graph_div, bookuri, bookRelations);
+  console.log("finished");
+
+  var graph2_div = document.getElementById('graph2');
+  var network = new vis.Network(
+    graph2_div,
+    data = {
+      nodes: [
+        {
+          id: "a",
+          label: "a",
+          level: 0,
+          color: "red"
+        },
+        {
+          id: "b",
+          label: "b",
+          level: 1,
+        },
+        {
+          id: "c",
+          label: "c",
+          level: 1,
+        },
+      ],
+      edges: [
+        {
+          from: "a",
+          to: "b",
+          label: "COMM",
+          font: {align: "middle"},
+          arrows: "to",
+          roundness: 0.4
+        },
+        {
+          from: "a",
+          to: "c",
+          label: "COMM",
+          font: {align: "middle"},
+          arrows: "to",
+          smooth: {
+            roundness: 0.8
+          },
+        },
+        {
+          from: "a",
+          to: "c",
+          label: "ABR",
+          font: {align: "middle"},
+          arrows: "to",
+          smooth: {
+            roundness: 0.3
+          },
+        },
+      ]
+    },
+    options = {
+      nodes: {
+        shape: "box"
+      },
+      edges: {
+        smooth: {
+          type: "curvedCW",
+          //type: 'cubicBezier',
+          //forceDirection: 'vertical',
+          //roundness: 1
+        }
+      },
+      layout: {
+        hierarchical: {
+          direction: 'UD',
+          nodeSpacing: 300,
+          //levelSeparation: 150,
+          //shakeTowards: "roots"
+          //sortMethod: "directed"
+        }
+      },
+      interaction: {
+        dragNodes: true,
+        hover: true
+      },
+      physics: true,
+      width: "100%",
+      height: "100%"
+    }
+  )
+});

--- a/test.html
+++ b/test.html
@@ -1,0 +1,53 @@
+<html>
+
+<head>
+    <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.10.16/datatables.min.css" /> -->
+    <link rel="stylesheet" type="text/css" href="css/styles.css" />
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+        crossorigin="anonymous"></script>
+    <!-- <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.16/datatables.min.js"></script> -->
+
+
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.0.0/dt-1.10.16/datatables.min.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.1/css/buttons.dataTables.min.css" />
+    <!-- old version -->
+    <!-- <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.0.0/dt-1.10.16/datatables.min.js"></script> -->
+    <!-- <script type="text/javascript" src="https://cdn.datatables.net/v/dt/jq-3.3.1/dt-1.10.18/b-1.5.6/b-html5-1.5.6/fh-3.1.4/r-2.2.2/rr-1.2.4/datatables.min.js"></script> -->
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.10.16/b-1.5.1/b-html5-1.5.1/cr-1.4.1/datatables.min.css"/>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/pdfmake.min.js"></script>
+    <!-- <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/vfs_fonts.js"></script> -->
+    <script type="text/javascript" src="js/vfs_fonts.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.10.16/b-1.5.1/b-html5-1.5.1/cr-1.4.1/datatables.min.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+
+    <script type="text/javascript" src="js/test.js"></script>
+    <script src="https://kit.fontawesome.com/03581ef0eb.js"></script>
+    <link href="https://fonts.googleapis.com/css?family=Amiri&display=swap" rel="stylesheet">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-TGJD7641K2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-TGJD7641K2');
+</script>
+<style>
+body{
+
+    font-family: 'Amiri', serif;
+}
+</style>
+</head>
+
+
+
+<body>
+<p>Test graph</p>
+<div id="graph"></div>
+<div id="graph2"></div>
+</body>
+</html>


### PR DESCRIPTION
Hi Sohail, 

I have changed the contents of the book relations popup. It now contains a graph of the network of the relations of the current book with other books, as defined in the metadata. 

If you use the search box for a book title or author, you will also find all related works to this book title / author. This was a request from the team, but I'm not sure how interesting this will be:  the more book relations we have, the fuzzier the search will become. At some point, we may have to add an option to include or exclude related works from the search. 

Best, 

Peter